### PR TITLE
Fix escaping of arguments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [ 18, 20, 21 ]
+        node-version: [ 18, 20, 22 ]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -31,5 +31,4 @@ jobs:
       - name: "Fetch & Unpack Allure Commandline from Maven Central"
         run: powershell -ExecutionPolicy Bypass -File fetch-source.ps1
         if: runner.os == 'Windows'
-      - run: npm link
-      - run: allure --version
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist
 allure-commandline.tgz
+allure-report
 
 #IDEA Files
 .idea/*

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
-#!/usr/bin/env node
 var path = require('path');
-var isWindows = path.sep === '\\';
-var allureCommand = 'allure' + (isWindows ? '.bat' : '');
 
+/**
+ *
+ * @param {string[]} args
+ */
 module.exports = function(args) {
-    return require('child_process').spawn(path.join(__dirname, 'dist/bin', allureCommand), args, {
+    return require('batspawn').spawn(path.join(__dirname, 'dist/bin', 'allure'), '.bat', args, {
         env: process.env,
         stdio: 'inherit',
-        shell: true,
     });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,25 @@
 {
   "name": "allure-commandline",
-  "version": "2.28.0",
+  "version": "2.32.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "allure-commandline",
-      "version": "2.28.0",
+      "version": "2.32.2",
       "license": "Apache-2.0",
+      "dependencies": {
+        "batspawn": "^1.0.1"
+      },
       "bin": {
         "allure": "bin/allure"
-      },
-      "devDependencies": {}
+      }
+    },
+    "node_modules/batspawn": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/batspawn/-/batspawn-1.0.1.tgz",
+      "integrity": "sha512-+pHM1Oq6kOKZnYX6ZmdzDGZLfPi6tiaspSOxvFHhiDFcRiCHFP6atdTEqa8pyPzZ1GebCZtr1AgO1k2tnPoHXA==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
     "index.js"
   ],
   "scripts": {
-    "test": "node ./bin/allure --version"
+    "test": "node ./bin/allure generate -c --single-file --name \"Web & Mobile\""
   },
   "repository": "https://github.com/allure-framework/allure-npm.git",
   "license": "Apache-2.0",
-  "devDependencies": {}
+  "dependencies": {
+    "batspawn": "^1.0.1"
+  }
 }


### PR DESCRIPTION
Commit a40732948a4a5ad9a23394eab16ddd24825726e0 enabled the `shell` option to fix running on Windows, but that's unsafe and breaks handling of spaces and special characters. Arguments provided to Windows batch files in particular need special escaping that's not provided by Node.js; use batspawn for that purpose.

Fixes #30
Fixes #45