### PR TITLE
Bump node version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 20
 
       - name: "Set release version"
         run: |


### PR DESCRIPTION
From version 8.0.0 onwards, `replace-in-file` package requires Node 18 or higher. 