### PR TITLE
Bump allure-commandline to 2.36.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "allure-commandline",
-  "version": "2.28.0",
+  "version": "2.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "allure-commandline",
-      "version": "2.28.0",
+      "version": "2.36.0",
       "license": "Apache-2.0",
       "bin": {
         "allure": "bin/allure"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "bin": {
     "allure": "bin/allure"
   },
-  "version": "2.35.1",
+  "version": "2.36.0",
   "description": "Wrapper to install Allure-commandline via NPM",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Bump allure-commandline to fix the vulnerability [CVE-2025-54988](https://github.com/advisories/GHSA-p72g-pv48-7w9x)